### PR TITLE
FIX pushing to ECR

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -41,10 +41,7 @@ Add these secrets in your repository settings (Settings → Secrets and variable
 
 Before the workflows can push to ECR, you need to:
 
-1. Create ECR repositories:
-   ```bash
-   ./scripts/aws/setup-ecr-repos.sh
-   ```
+1. Ensure the ECR repository `my-app-repository` exists in your AWS account
 
 2. Ensure AWS credentials have permissions for:
    - `ecr:GetAuthorizationToken`
@@ -60,12 +57,12 @@ Before the workflows can push to ECR, you need to:
 2. **version-tag.yml** creates semantic version (e.g., v1.2.3)
 3. **build-publish-deploy.yml** triggers:
    - Builds Docker images
-   - Tags images with version: `v1.2.3` and `latest`
-   - Pushes to ECR repositories:
-     - `consent-demo/music-service`
-     - `consent-demo/bank-service`
-     - `consent-demo/music-service-ui`
-     - `consent-demo/bank-service-ui`
+   - Tags images with version and service name
+   - Pushes to ECR repository `my-app-repository` with tags:
+     - `music-service-v1.2.3` / `music-service-latest`
+     - `bank-service-v1.2.3` / `bank-service-latest`
+     - `music-service-ui-v1.2.3` / `music-service-ui-latest`
+     - `bank-service-ui-v1.2.3` / `bank-service-ui-latest`
    - Deploys to production server
 
 ## Version Management

--- a/.github/workflows/build-publish-deploy.yml
+++ b/.github/workflows/build-publish-deploy.yml
@@ -35,7 +35,8 @@ jobs:
 
       - name: Login to Amazon ECR
         run: |
-          aws ecr get-login-password --region ${{ secrets.AWS_REGION || 'us-east-1' }} | docker login --username AWS --password-stdin 945513556588.dkr.ecr.us-east-1.amazonaws.com
+          AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query 'Account' --output text)
+          aws ecr get-login-password --region ${{ secrets.AWS_REGION || 'us-east-1' }} | docker login --username AWS --password-stdin ${AWS_ACCOUNT_ID}.dkr.ecr.${{ secrets.AWS_REGION || 'us-east-1' }}.amazonaws.com
 
       - name: Push images to ECR
         env:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,7 +121,7 @@ npm run build      # Build for production
 
 ### Repository Structure
 All services share a single ECR repository with service-specific tags:
-- Repository: `945513556588.dkr.ecr.us-east-1.amazonaws.com/my-app-repository`
+- Repository: `<AWS_ACCOUNT_ID>.dkr.ecr.<AWS_REGION>.amazonaws.com/my-app-repository`
 - Image tags:
   - `music-service-v1.2.3` / `music-service-latest`
   - `bank-service-v1.2.3` / `bank-service-latest`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,9 +51,6 @@ cd bank-service && python -m pytest -v tests/test_customers.py::test_create_cust
 # Test identity server token acquisition
 ./scripts/identity-server/test-tokens.sh
 
-# Setup ECR repositories (run once before first push)
-./scripts/aws/setup-ecr-repos.sh
-
 # Push all Docker images to AWS ECR
 make push
 
@@ -123,11 +120,13 @@ npm run build      # Build for production
 ## AWS ECR Deployment
 
 ### Repository Structure
-Each service has its own ECR repository:
-- `945513556588.dkr.ecr.us-east-1.amazonaws.com/consent-demo/music-service`
-- `945513556588.dkr.ecr.us-east-1.amazonaws.com/consent-demo/bank-service`
-- `945513556588.dkr.ecr.us-east-1.amazonaws.com/consent-demo/music-service-ui`
-- `945513556588.dkr.ecr.us-east-1.amazonaws.com/consent-demo/bank-service-ui`
+All services share a single ECR repository with service-specific tags:
+- Repository: `945513556588.dkr.ecr.us-east-1.amazonaws.com/my-app-repository`
+- Image tags:
+  - `music-service-v1.2.3` / `music-service-latest`
+  - `bank-service-v1.2.3` / `bank-service-latest`
+  - `music-service-ui-v1.2.3` / `music-service-ui-latest`
+  - `bank-service-ui-v1.2.3` / `bank-service-ui-latest`
 
 ### Versioning Strategy
 - **Production (master branch)**: Semantic versioning with git tags (e.g., `v1.2.3`)
@@ -146,5 +145,5 @@ Each service has its own ECR repository:
 ### First-time Setup
 Before pushing images for the first time:
 1. Ensure AWS credentials are in `.env` file
-2. Run `./scripts/aws/setup-ecr-repos.sh` to create repositories and lifecycle policies
+2. Ensure the ECR repository `my-app-repository` exists in your AWS account
 3. Use `make push` to build and push all images

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,7 +132,7 @@ All services share a single ECR repository with service-specific tags:
 - **Production (master branch)**: Semantic versioning with git tags (e.g., `v1.2.3`)
   - Tags are automatically created when pushing to master via GitHub Actions
   - Each push to master bumps the patch version by default
-- **Development branches**: Tagged as `dev-<branch>-<commit-hash>`
+- **Development branches**: Tagged as `dev-<branch>-<commit-hash>` (branch names are sanitized)
 - A `latest` tag always points to the most recent production version
 - Lifecycle policies automatically retain only the 5 most recent images
 

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,9 @@ BANK_UI_PORT ?= 8200
 ECR_REGISTRY = 945513556588.dkr.ecr.us-east-1.amazonaws.com
 ECR_REPOSITORY = my-app-repository
 
+# Service names
+SERVICES = music-service bank-service music-service-ui bank-service-ui
+
 # Version detection using git tags
 VERSION := $(shell git describe --tags --always --dirty 2>/dev/null || echo "v0.0.0")
 BRANCH := $(shell git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
@@ -70,29 +73,13 @@ push: build
 	@echo "Authenticating with AWS ECR..."
 	aws ecr get-login-password --region $(AWS_REGION) | docker login --username AWS --password-stdin $(ECR_REGISTRY)
 	
-	@echo "Pushing music-service with version $(VERSION)..."
-	docker tag music-service:latest $(ECR_REGISTRY)/$(ECR_REPOSITORY):music-service-$(VERSION)
-	docker tag music-service:latest $(ECR_REGISTRY)/$(ECR_REPOSITORY):music-service-latest
-	docker push $(ECR_REGISTRY)/$(ECR_REPOSITORY):music-service-$(VERSION)
-	docker push $(ECR_REGISTRY)/$(ECR_REPOSITORY):music-service-latest
-	
-	@echo "Pushing bank-service with version $(VERSION)..."
-	docker tag bank-service:latest $(ECR_REGISTRY)/$(ECR_REPOSITORY):bank-service-$(VERSION)
-	docker tag bank-service:latest $(ECR_REGISTRY)/$(ECR_REPOSITORY):bank-service-latest
-	docker push $(ECR_REGISTRY)/$(ECR_REPOSITORY):bank-service-$(VERSION)
-	docker push $(ECR_REGISTRY)/$(ECR_REPOSITORY):bank-service-latest
-	
-	@echo "Pushing music-service-ui with version $(VERSION)..."
-	docker tag music-service-ui:latest $(ECR_REGISTRY)/$(ECR_REPOSITORY):music-service-ui-$(VERSION)
-	docker tag music-service-ui:latest $(ECR_REGISTRY)/$(ECR_REPOSITORY):music-service-ui-latest
-	docker push $(ECR_REGISTRY)/$(ECR_REPOSITORY):music-service-ui-$(VERSION)
-	docker push $(ECR_REGISTRY)/$(ECR_REPOSITORY):music-service-ui-latest
-	
-	@echo "Pushing bank-service-ui with version $(VERSION)..."
-	docker tag bank-service-ui:latest $(ECR_REGISTRY)/$(ECR_REPOSITORY):bank-service-ui-$(VERSION)
-	docker tag bank-service-ui:latest $(ECR_REGISTRY)/$(ECR_REPOSITORY):bank-service-ui-latest
-	docker push $(ECR_REGISTRY)/$(ECR_REPOSITORY):bank-service-ui-$(VERSION)
-	docker push $(ECR_REGISTRY)/$(ECR_REPOSITORY):bank-service-ui-latest
+	@for service in $(SERVICES); do \
+		echo "Pushing $$service with version $(VERSION)..."; \
+		docker tag $$service:latest $(ECR_REGISTRY)/$(ECR_REPOSITORY):$$service-$(VERSION); \
+		docker tag $$service:latest $(ECR_REGISTRY)/$(ECR_REPOSITORY):$$service-latest; \
+		docker push $(ECR_REGISTRY)/$(ECR_REPOSITORY):$$service-$(VERSION); \
+		docker push $(ECR_REGISTRY)/$(ECR_REPOSITORY):$$service-latest; \
+	done
 	
 	@echo "All images pushed successfully to ECR with version $(VERSION)!"
 
@@ -101,21 +88,11 @@ push-dev: build
 	@echo "Authenticating with AWS ECR..."
 	aws ecr get-login-password --region $(AWS_REGION) | docker login --username AWS --password-stdin $(ECR_REGISTRY)
 	
-	@echo "Pushing music-service (dev)..."
-	docker tag music-service:latest $(ECR_REGISTRY)/$(ECR_REPOSITORY):music-service-dev-$(BRANCH)-$(SHORT_HASH)
-	docker push $(ECR_REGISTRY)/$(ECR_REPOSITORY):music-service-dev-$(BRANCH)-$(SHORT_HASH)
-	
-	@echo "Pushing bank-service (dev)..."
-	docker tag bank-service:latest $(ECR_REGISTRY)/$(ECR_REPOSITORY):bank-service-dev-$(BRANCH)-$(SHORT_HASH)
-	docker push $(ECR_REGISTRY)/$(ECR_REPOSITORY):bank-service-dev-$(BRANCH)-$(SHORT_HASH)
-	
-	@echo "Pushing music-service-ui (dev)..."
-	docker tag music-service-ui:latest $(ECR_REGISTRY)/$(ECR_REPOSITORY):music-service-ui-dev-$(BRANCH)-$(SHORT_HASH)
-	docker push $(ECR_REGISTRY)/$(ECR_REPOSITORY):music-service-ui-dev-$(BRANCH)-$(SHORT_HASH)
-	
-	@echo "Pushing bank-service-ui (dev)..."
-	docker tag bank-service-ui:latest $(ECR_REGISTRY)/$(ECR_REPOSITORY):bank-service-ui-dev-$(BRANCH)-$(SHORT_HASH)
-	docker push $(ECR_REGISTRY)/$(ECR_REPOSITORY):bank-service-ui-dev-$(BRANCH)-$(SHORT_HASH)
+	@for service in $(SERVICES); do \
+		echo "Pushing $$service (dev)..."; \
+		docker tag $$service:latest $(ECR_REGISTRY)/$(ECR_REPOSITORY):$$service-dev-$(BRANCH)-$(SHORT_HASH); \
+		docker push $(ECR_REGISTRY)/$(ECR_REPOSITORY):$$service-dev-$(BRANCH)-$(SHORT_HASH); \
+	done
 	
 	@echo "Development images pushed with tag: dev-$(BRANCH)-$(SHORT_HASH)"
 

--- a/Makefile
+++ b/Makefile
@@ -15,10 +15,7 @@ BANK_UI_PORT ?= 8200
 
 # ECR configuration
 ECR_REGISTRY = 945513556588.dkr.ecr.us-east-1.amazonaws.com
-ECR_MUSIC_SERVICE = consent-demo/music-service
-ECR_BANK_SERVICE = consent-demo/bank-service
-ECR_MUSIC_SERVICE_UI = consent-demo/music-service-ui
-ECR_BANK_SERVICE_UI = consent-demo/bank-service-ui
+ECR_REPOSITORY = my-app-repository
 
 # Version detection using git tags
 VERSION := $(shell git describe --tags --always --dirty 2>/dev/null || echo "v0.0.0")
@@ -74,28 +71,28 @@ push: build
 	aws ecr get-login-password --region $(AWS_REGION) | docker login --username AWS --password-stdin $(ECR_REGISTRY)
 	
 	@echo "Pushing music-service with version $(VERSION)..."
-	docker tag music-service:latest $(ECR_REGISTRY)/$(ECR_MUSIC_SERVICE):$(VERSION)
-	docker tag music-service:latest $(ECR_REGISTRY)/$(ECR_MUSIC_SERVICE):latest
-	docker push $(ECR_REGISTRY)/$(ECR_MUSIC_SERVICE):$(VERSION)
-	docker push $(ECR_REGISTRY)/$(ECR_MUSIC_SERVICE):latest
+	docker tag music-service:latest $(ECR_REGISTRY)/$(ECR_REPOSITORY):music-service-$(VERSION)
+	docker tag music-service:latest $(ECR_REGISTRY)/$(ECR_REPOSITORY):music-service-latest
+	docker push $(ECR_REGISTRY)/$(ECR_REPOSITORY):music-service-$(VERSION)
+	docker push $(ECR_REGISTRY)/$(ECR_REPOSITORY):music-service-latest
 	
 	@echo "Pushing bank-service with version $(VERSION)..."
-	docker tag bank-service:latest $(ECR_REGISTRY)/$(ECR_BANK_SERVICE):$(VERSION)
-	docker tag bank-service:latest $(ECR_REGISTRY)/$(ECR_BANK_SERVICE):latest
-	docker push $(ECR_REGISTRY)/$(ECR_BANK_SERVICE):$(VERSION)
-	docker push $(ECR_REGISTRY)/$(ECR_BANK_SERVICE):latest
+	docker tag bank-service:latest $(ECR_REGISTRY)/$(ECR_REPOSITORY):bank-service-$(VERSION)
+	docker tag bank-service:latest $(ECR_REGISTRY)/$(ECR_REPOSITORY):bank-service-latest
+	docker push $(ECR_REGISTRY)/$(ECR_REPOSITORY):bank-service-$(VERSION)
+	docker push $(ECR_REGISTRY)/$(ECR_REPOSITORY):bank-service-latest
 	
 	@echo "Pushing music-service-ui with version $(VERSION)..."
-	docker tag music-service-ui:latest $(ECR_REGISTRY)/$(ECR_MUSIC_SERVICE_UI):$(VERSION)
-	docker tag music-service-ui:latest $(ECR_REGISTRY)/$(ECR_MUSIC_SERVICE_UI):latest
-	docker push $(ECR_REGISTRY)/$(ECR_MUSIC_SERVICE_UI):$(VERSION)
-	docker push $(ECR_REGISTRY)/$(ECR_MUSIC_SERVICE_UI):latest
+	docker tag music-service-ui:latest $(ECR_REGISTRY)/$(ECR_REPOSITORY):music-service-ui-$(VERSION)
+	docker tag music-service-ui:latest $(ECR_REGISTRY)/$(ECR_REPOSITORY):music-service-ui-latest
+	docker push $(ECR_REGISTRY)/$(ECR_REPOSITORY):music-service-ui-$(VERSION)
+	docker push $(ECR_REGISTRY)/$(ECR_REPOSITORY):music-service-ui-latest
 	
 	@echo "Pushing bank-service-ui with version $(VERSION)..."
-	docker tag bank-service-ui:latest $(ECR_REGISTRY)/$(ECR_BANK_SERVICE_UI):$(VERSION)
-	docker tag bank-service-ui:latest $(ECR_REGISTRY)/$(ECR_BANK_SERVICE_UI):latest
-	docker push $(ECR_REGISTRY)/$(ECR_BANK_SERVICE_UI):$(VERSION)
-	docker push $(ECR_REGISTRY)/$(ECR_BANK_SERVICE_UI):latest
+	docker tag bank-service-ui:latest $(ECR_REGISTRY)/$(ECR_REPOSITORY):bank-service-ui-$(VERSION)
+	docker tag bank-service-ui:latest $(ECR_REGISTRY)/$(ECR_REPOSITORY):bank-service-ui-latest
+	docker push $(ECR_REGISTRY)/$(ECR_REPOSITORY):bank-service-ui-$(VERSION)
+	docker push $(ECR_REGISTRY)/$(ECR_REPOSITORY):bank-service-ui-latest
 	
 	@echo "All images pushed successfully to ECR with version $(VERSION)!"
 
@@ -105,20 +102,20 @@ push-dev: build
 	aws ecr get-login-password --region $(AWS_REGION) | docker login --username AWS --password-stdin $(ECR_REGISTRY)
 	
 	@echo "Pushing music-service (dev)..."
-	docker tag music-service:latest $(ECR_REGISTRY)/$(ECR_MUSIC_SERVICE):dev-$(BRANCH)-$(SHORT_HASH)
-	docker push $(ECR_REGISTRY)/$(ECR_MUSIC_SERVICE):dev-$(BRANCH)-$(SHORT_HASH)
+	docker tag music-service:latest $(ECR_REGISTRY)/$(ECR_REPOSITORY):music-service-dev-$(BRANCH)-$(SHORT_HASH)
+	docker push $(ECR_REGISTRY)/$(ECR_REPOSITORY):music-service-dev-$(BRANCH)-$(SHORT_HASH)
 	
 	@echo "Pushing bank-service (dev)..."
-	docker tag bank-service:latest $(ECR_REGISTRY)/$(ECR_BANK_SERVICE):dev-$(BRANCH)-$(SHORT_HASH)
-	docker push $(ECR_REGISTRY)/$(ECR_BANK_SERVICE):dev-$(BRANCH)-$(SHORT_HASH)
+	docker tag bank-service:latest $(ECR_REGISTRY)/$(ECR_REPOSITORY):bank-service-dev-$(BRANCH)-$(SHORT_HASH)
+	docker push $(ECR_REGISTRY)/$(ECR_REPOSITORY):bank-service-dev-$(BRANCH)-$(SHORT_HASH)
 	
 	@echo "Pushing music-service-ui (dev)..."
-	docker tag music-service-ui:latest $(ECR_REGISTRY)/$(ECR_MUSIC_SERVICE_UI):dev-$(BRANCH)-$(SHORT_HASH)
-	docker push $(ECR_REGISTRY)/$(ECR_MUSIC_SERVICE_UI):dev-$(BRANCH)-$(SHORT_HASH)
+	docker tag music-service-ui:latest $(ECR_REGISTRY)/$(ECR_REPOSITORY):music-service-ui-dev-$(BRANCH)-$(SHORT_HASH)
+	docker push $(ECR_REGISTRY)/$(ECR_REPOSITORY):music-service-ui-dev-$(BRANCH)-$(SHORT_HASH)
 	
 	@echo "Pushing bank-service-ui (dev)..."
-	docker tag bank-service-ui:latest $(ECR_REGISTRY)/$(ECR_BANK_SERVICE_UI):dev-$(BRANCH)-$(SHORT_HASH)
-	docker push $(ECR_REGISTRY)/$(ECR_BANK_SERVICE_UI):dev-$(BRANCH)-$(SHORT_HASH)
+	docker tag bank-service-ui:latest $(ECR_REGISTRY)/$(ECR_REPOSITORY):bank-service-ui-dev-$(BRANCH)-$(SHORT_HASH)
+	docker push $(ECR_REGISTRY)/$(ECR_REPOSITORY):bank-service-ui-dev-$(BRANCH)-$(SHORT_HASH)
 	
 	@echo "Development images pushed with tag: dev-$(BRANCH)-$(SHORT_HASH)"
 

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,6 @@
 export AWS_ACCESS_KEY_ID
 export AWS_SECRET_ACCESS_KEY
 export AWS_SESSION_TOKEN
-export AWS_REGION
 
 # Port configuration
 MUSIC_PORT ?= 8101
@@ -14,7 +13,10 @@ MUSIC_UI_PORT ?= 8100
 BANK_UI_PORT ?= 8200
 
 # ECR configuration
-ECR_REGISTRY = 945513556588.dkr.ecr.us-east-1.amazonaws.com
+AWS_ACCOUNT_ID := $(shell aws sts get-caller-identity --query 'Account' --output text 2>/dev/null || echo "000000000000")
+AWS_REGION ?= us-east-1
+export AWS_REGION
+ECR_REGISTRY = $(AWS_ACCOUNT_ID).dkr.ecr.$(AWS_REGION).amazonaws.com
 ECR_REPOSITORY = my-app-repository
 
 # Service names


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Modify the ECR deployment process to use a single ECR repository for all services, update the naming convention of image tags, and automate account-based repository URL detection within the deployment scripts.

### Why are these changes being made?

This change streamlines the repository setup by consolidating multiple service-specific ECR repositories into a single repository, simplifying the deployment and management process. It also eliminates hardcoding of account and region details, improving the maintainability and flexibility of the deployment scripts in multi-account scenarios.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated deployment instructions to use a single shared ECR repository for all services, with service-specific tags for Docker images.
  * Simplified setup steps by removing the need to create multiple ECR repositories.

* **Chores**
  * Refactored Makefile to consolidate ECR repository variables into a single repository variable, streamlining Docker image tagging and pushing processes.
  * Enhanced AWS ECR login process to dynamically detect AWS account ID and region for improved flexibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->