### PR TITLE
FIX push docker image

### DIFF
--- a/.github/workflows/build-publish-deploy.yml
+++ b/.github/workflows/build-publish-deploy.yml
@@ -46,21 +46,21 @@ jobs:
           echo "Pushing Docker images to ECR..."
           make push
 
-      - name: Build artifact for S3
-        run: |
-          echo "Building artifact for S3 deployment..."
-          # Original build artifact command if needed
-          if [ -d "dist" ]; then
-            echo "Built artifact:"
-            ls -la dist/
-          fi
+      # - name: Build artifact for S3
+      #   run: |
+      #     echo "Building artifact for S3 deployment..."
+      #     # Original build artifact command if needed
+      #     if [ -d "dist" ]; then
+      #       echo "Built artifact:"
+      #       ls -la dist/
+      #     fi
 
-      - name: Publish to AWS S3
-        run: |
-          # Run the Makefile publish target which handles upload and retention
-          export AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }}
-          export AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          make publish
+      # - name: Publish to AWS S3
+      #   run: |
+      #     # Run the Makefile publish target which handles upload and retention
+      #     export AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }}
+      #     export AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      #     make publish
 
       # Once validated, you can re-enable the Tailscale connection step
       - name: Connect Tailscale


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Comment out the build and publish steps related to AWS S3 in the GitHub Actions workflow.

### Why are these changes being made?

These changes are being implemented to disable the S3-related steps as they are currently not required, while still retaining the ability to quickly reinstate them if needed. This streamlines the workflow to focus on pushing Docker images to ECR, reflecting the current deployment needs without removing the existing S3 logic entirely.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Disabled steps related to building and publishing artifacts to AWS S3 in the deployment workflow. Other deployment steps remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->